### PR TITLE
Add two patches from debian for armhf support

### DIFF
--- a/fixed.h
+++ b/fixed.h
@@ -275,12 +275,25 @@ mad_fixed_t mad_f_mul_inline(mad_fixed_t x, mad_fixed_t y)
 	 : "+r" (lo), "+r" (hi)  \
 	 : "%r" (x), "r" (y))
 
+#ifdef __thumb__
+/* In Thumb-2, the RSB-immediate instruction is only allowed with a zero
+	operand.  If needed this code can also support Thumb-1 
+	(simply append "s" to the end of the second two instructions). */
+#  define MAD_F_MLN(hi, lo)  \
+    asm ("rsbs        %0, %0, #0\n\t"  \
+	 "sbc   %1, %1, %1\n\t"  \
+	 "sub   %1, %1, %2"  \
+	 : "+&r" (lo), "=&r" (hi)  \
+	 : "r" (hi)  \
+	 : "cc")
+#else /* ! __thumb__ */
 #  define MAD_F_MLN(hi, lo)  \
     asm ("rsbs	%0, %2, #0\n\t"  \
 	 "rsc	%1, %3, #0"  \
-	 : "=r" (lo), "=r" (hi)  \
+	 : "=&r" (lo), "=r" (hi)  \
 	 : "0" (lo), "1" (hi)  \
 	 : "cc")
+#endif /* __thumb__ */
 
 #  define mad_f_scale64(hi, lo)  \
     ({ mad_fixed_t __result;  \

--- a/imdct_l_arm.S
+++ b/imdct_l_arm.S
@@ -468,7 +468,7 @@ _III_imdct_l:
 
     @----
 
-    add     r2, pc, #(imdct36_long_karray-.-8)  @ r2 = base address of Knn array (PIC safe ?)
+    adr     r2, imdct36_long_karray
 
 
 loop:


### PR DESCRIPTION
libmad builds on armhf fail due to thumb2 instructions having changed from thumb1. libmad only supports thumb1 so these patches add in thumb2 capability to allow armhf builds to succeed.